### PR TITLE
Add AlphaVantage search functionality

### DIFF
--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -37,6 +37,7 @@ Further documentation can be found here: https://www.alphavantage.co/documentati
     * [.timeSeriesDaily(symbol, compact, adjusted)](#AlphaVantage+timeSeriesDaily) ⇒ <code>Promise.&lt;Array&gt;</code>
     * [.timeSeriesWeekly(symbol, adjusted)](#AlphaVantage+timeSeriesWeekly) ⇒ <code>Promise.&lt;Array&gt;</code>
     * [.timeSeriesMonthly(symbol, adjusted)](#AlphaVantage+timeSeriesMonthly) ⇒ <code>Promise.&lt;Array&gt;</code>
+    * [.search(keyword)](#AlphaVantage+search) ⇒ <code>Promise.&lt;Array&gt;</code>
     * [.sma(symbol, interval, timePeriod, seriesType, seriesType, seriesType)](#AlphaVantage+sma) ⇒ <code>Promise.&lt;Array&gt;</code>
     * [.ema(symbol, interval, timePeriod, seriesType)](#AlphaVantage+ema) ⇒ <code>Promise.&lt;Array&gt;</code>
     * [.wma(symbol, interval, timePeriod, seriesType)](#AlphaVantage+wma) ⇒ <code>Promise.&lt;Array&gt;</code>
@@ -127,6 +128,18 @@ Returns an array of quotes for the equity specified, covering up to 20 years of 
 | --- | --- | --- |
 | symbol | <code>String</code> |  |
 | adjusted | <code>Boolean</code> | If true, prices will be adjusted for split/dividend events. |
+
+<a name="AlphaVantage+search"></a>
+
+### alphaVantage.search(keyword) ⇒ <code>Promise.&lt;Array&gt;</code>
+Returns an array of matches for the search keyword.
+
+**Kind**: instance method of [<code>AlphaVantage</code>](#AlphaVantage)  
+**Author**: Nicklas Laine Overgaard <https://github.com/nover>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyword | <code>String</code> | The search keyword(s), e.g Microsoft or Apple |
 
 <a name="AlphaVantage+sma"></a>
 

--- a/objects/globals/Match.js
+++ b/objects/globals/Match.js
@@ -1,0 +1,102 @@
+class Match {
+	/**
+	 * Creats a AlphaVantage Match instance
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @constructor
+	 * @param {Object} object
+	 * @property {String} "1. symbol"
+	 * @property {String} "2. name"
+	 * @property {String} "3. type"
+	 * @property {String} "4. region"
+	 * @property {String} "5. marketOpen"
+	 * @property {String} "6. marketCloes"
+	 * @property {String} "7. timezone"
+	 * @property {String} "8. currency"
+	 * @property {Number} "9. matchScore"
+	 */
+	constructor(object) {
+		this.symbol = object['1. symbol'];
+		this.name = object['2. name'];
+		this.type = object['3. type'];
+		this.region = object['4. region'];
+		this.marketOpen = object['5. marketOpen'];
+		this.marketClose = object['6. marketClose'];
+		this.timezone = object['7. timezone'];
+		this.currency = object['8. currency'];
+		this.matchScore = Number(object['9. matchScore']);
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getSymbol() {
+		return this.symbol;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getName() {
+		return this.name;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getType() {
+		return this.type;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getRegion() {
+		return this.region;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getMarketOpen() {
+		return this.marketOpen;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getMarketClose() {
+		return this.marketClose;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getTimezone() {
+		return this.timezone;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getCurrency() {
+		return this.currency;
+	}
+
+	/**
+	 * @author Nicklas Laine Overgaard <https://github.com/nover>
+	 * @returns {String}
+	 */
+	getMatchScore() {
+		return this.matchScore;
+	}
+}
+
+module.exports = Match;

--- a/test.js
+++ b/test.js
@@ -181,6 +181,30 @@ Object.getOwnPropertyNames(IEX).forEach(f => {
 		});
 });
 
+
+// AlphaVantage
+const AlphaVantage = algotrader.Data.AlphaVantage;
+const ALPHA_VANTAGE_API_KEY = process.env.ALPHA_VANTAGE_API_KEY	|| 'demo';
+test('data | alpha-vantage > search', t => {
+	const av = new AlphaVantage(ALPHA_VANTAGE_API_KEY);
+
+	return av.search('microsoft').then(data => {
+		t.true(data.length > 0);
+
+		for (const item of data) {
+			t.truthy(item.symbol);
+			t.truthy(item.name);
+			t.truthy(item.type);
+			t.truthy(item.region);
+			t.truthy(item.marketOpen);
+			t.truthy(item.marketClose);
+			t.truthy(item.timezone);
+			t.truthy(item.currency);
+			t.truthy(item.matchScore);
+		}
+	});
+});
+
 /**
  * Algorithm Library
  */


### PR DESCRIPTION
This PR adds the AlphaVantage search API to the `AlphaVantage` class 

List of changes made:

- add `search(keyword:string)` method
- non breaking refactor of `_requestor` to enable mapping of search responses
- add test
- update documentation
