### PR TITLE
Fix bug for when Portfolio contains only one item

### DIFF
--- a/objects/broker/robinhood/User.js
+++ b/objects/broker/robinhood/User.js
@@ -619,6 +619,8 @@ class User extends Robinhood {
 			}, (error, response, body) => {
 				Robinhood.handleResponse(error, response, body, _this.token, res => {
 					let array = [];
+					
+					if (!Array.isArray(res)) res = [res];
 					async.forEachOf(res, (position, key, callback) => {
 						position.quantity = Number(position.quantity);
 						if (position.quantity !== 0) {


### PR DESCRIPTION
When a user's portfolio contains only one item, res is an object rather than an array.